### PR TITLE
Remove workaround for bad sub-region 2 data.

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -107,10 +107,6 @@ export function fetchRegionalTrendLines(): Promise<RegionalTrendLine[]> {
               `Load regional trend data with ${results.data.length} rows`
             );
             results.data.map((d) => {
-              // temporary work around for
-              if (d.sub_region_2_code.length == 4) {
-                d.sub_region_2_code = "0" + d.sub_region_2_code;
-              }
               const parsedRow: RegionalTrendLine = {
                 date: d.date,
                 country_region: d.country_region,


### PR DESCRIPTION
Removed the work around to add a leading zero to four digit
codes in the sub_region_2_code field. The buggy script that
was processing the field as an integer and removing the leading
zero has been fixed.