### PR TITLE
Fix gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,10 @@
 name: github pages
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
Update configuration to run on the main branch and pull from the `public` dir on build (which is the default).