### PR TITLE
Fix issue #17.

### DIFF
--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -578,7 +578,7 @@
     })
 
     Promise.all([latestRegionOneData, latestRegionTwoData]).then((values) => {
-	    createMap(values[0], values[1], selectedMapTrendId);
+	    createMap(values[0], values[1], selectedMapTrendId, regions, onMapSelection);
 	  });
   });
 
@@ -594,6 +594,13 @@
         setSelectedState(selectedRegion.sub_region_1_code);
       }
     }
+  }
+  
+  function onMapSelection(id: string): void {
+    params.update((p) => {
+      p.placeId = id;
+      return p;
+    });
   }
 
 </script>

--- a/src/choropleth.js
+++ b/src/choropleth.js
@@ -16,6 +16,7 @@
 
 import { mesh, feature } from "topojson-client";
 import {
+  buildRegionCodeToPlaceIdMapping,
   fipsCodeFromElementId,
   regionOneToFipsCode,
   stateFipsCodeFromCounty,
@@ -36,6 +37,9 @@ let latestStateData;
 let latestCountyData;
 let selectedTrend;
 
+let regionCodesToPlaceId;
+let selectionCallback;
+
 //
 // Exports for clients
 //
@@ -45,7 +49,7 @@ export const mapBounds = {
   margin: 30,
 };
 
-export function createMap(stateData, countyData, trend) {
+export function createMap(stateData, countyData, trend, regions, selectionFn) {
   latestCountyData = countyData;
   selectedTrend = trend;
 
@@ -56,6 +60,9 @@ export function createMap(stateData, countyData, trend) {
   stateData.forEach((value, key) => {
     latestStateData.set(regionOneToFipsCode.get(key), value);
   });
+
+  regionCodesToPlaceId = buildRegionCodeToPlaceIdMapping(regions);
+  selectionCallback = selectionFn;
 
   initializeMap();
   colorizeMap(trend);
@@ -483,6 +490,7 @@ function hideMapCallout(event, d) {
 
 function stateSelectionOnClickHandler(event, d) {
   setSelectedState(fipsCodeFromElementId(this.id));
+  selectionCallback(regionCodesToPlaceId.get(fipsCodeFromElementId(this.id)));
 }
 
 function enterStateBoundsHandler(event, d) {
@@ -502,6 +510,7 @@ function inStateMovementHandler(event, d) {
 //
 function countySelectionOnClickHandler(event, d) {
   activateSelectedCounty(fipsCodeFromElementId(this.id));
+  selectionCallback(regionCodesToPlaceId.get(fipsCodeFromElementId(this.id)));
 }
 
 function enterCountyBoundsHandler(event, d) {

--- a/src/geo-utils.ts
+++ b/src/geo-utils.ts
@@ -16,6 +16,9 @@
 
 import { feature } from "topojson-client";
 import * as us from "us-atlas/counties-albers-10m.json";
+import type { Region } from "./data";
+
+let regionCodesToPlaceId: Map<string, string>;
 
 export const regionOneToFipsCode: Map<string, string> = new Map([
   ["US-AL", "01"],
@@ -87,4 +90,20 @@ export function stateFipsCodeFromCounty(countyFipsCode: string): string {
 
 export function fipsCodeFromElementId(id: string): string {
   return id.slice(5);
+}
+
+export function buildRegionCodeToPlaceIdMapping(
+  regions: Region[]
+): Map<string, string> {
+  return regions.reduce((acc, region) => {
+    if (region.sub_region_2_code == "") {
+      acc.set(
+        regionOneToFipsCode.get(region.sub_region_1_code),
+        region.place_id
+      );
+    } else {
+      acc.set(region.sub_region_2_code, region.place_id);
+    }
+    return acc;
+  }, new Map<string, string>());
 }


### PR DESCRIPTION
Added code in geo-utils.ts to build a mapping from sub-region 1 or
sub-region 2 code to the corresponding placeId. This mapping is used
in the choropleth map when a selection is made to set the new placeId
via a callback provided from TrendsOverview.svelte.