### PR TITLE
Fix workflow branch name

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,10 +1,10 @@
 name: github pages
 
 on: 
-  workflow_dispatch:
   push:
     branches:
-      - master
+      - main
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
The default branch is "main" not "master".

I was wondering why gh-pages wasn't being rebuild when PRs are merged.  This is why.