### PR TITLE
Temporarily remove automated builds to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,9 @@
 name: github pages
 
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
In preparation to open this repo up to the public, we need to temporarily disable the `gh-pages` branch, and disable builds publishing there.

This PR just removes the automated build to github pages.