### PR TITLE
Fix relative script paths

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,12 +8,12 @@
 		We’re releasing this data to inform public health vaccine-confidence efforts.'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
 
-	<title>Svelte app</title>
+	<title>COVID-19 Vaccine Search Insights</title>
 
 	<link rel='icon' type='image/x-icon' href='/favicon.ico'>
-	<link rel='stylesheet' href='/build/bundle.css'>
+	<link rel='stylesheet' href='./build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
+	<script defer src='./build/bundle.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
Change the script locations to use relative paths because the public gh-pages URL is to a subdirectory.