### PR TITLE
Cleanup and update to info button popups.

### DIFF
--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -846,6 +846,20 @@
 
   let popupId: string;
 
+  function selectInfoPopup(): string {
+    switch (selectedMapTrendId) {
+      case "vaccination":
+        return "#info-popup-vaccine";
+      case "intent":
+        return "#info-popup-intent";
+      case "safety":
+        return "#info-popup-safety";
+      default:
+        console.log(`Unknown trend: ${selectedMapTrendId} set on map`);
+        return "";
+    }
+  }
+
   function handleLegendInfoPopup(event, id): void {
     if (popupId) {
       dismissLegendInfoPopup(event);
@@ -1090,7 +1104,7 @@
               <div
                 class="map-info-button"
                 on:click={(e) => {
-                  handleLegendInfoPopup(e, "#info-popup");
+                  handleLegendInfoPopup(e, selectInfoPopup());
                 }}
               >
                 <span class="material-icons-outlined">info</span>
@@ -1133,16 +1147,6 @@
         </div>
 
         <!-- Info Popups -->
-        <div id="info-popup" class="info-popup">
-          <h3 class="info-header">Interest</h3>
-          <p class="info-text">
-            A scaled value, showing relative interest, that you can compare
-            across regions and times.
-          </p>
-          <p>
-            <a href="#about" class="info-link">Learn more</a>
-          </p>
-        </div>
 
         <div id="info-popup-vaccine" class="info-popup">
           <h3 class="info-header">
@@ -1150,7 +1154,7 @@
           </h3>
           <p class="info-text">
             Search interest in any aspect of COVID-19 vaccination. A scaled
-            value that you can compare across regions and times.
+            value that you can compare across regions, times, or topics.
           </p>
           <p>
             <a href="#about" class="info-link">Learn more</a>
@@ -1164,7 +1168,7 @@
           <p class="info-text">
             Search interest in the eligibility, availability, and accessibility
             of COVID-19 vaccines. A scaled value that you can compare across
-            regions and times.
+            regions, times, or topics.
           </p>
           <p>
             <a href="#about" class="info-link">Learn more</a>
@@ -1177,7 +1181,8 @@
           </h3>
           <p class="info-text">
             Search interest in the safety and side effects of COVID-19 vaccines.
-            A scaled value that you can compare across regions and times.
+            A scaled value that you can compare across regions, times, or
+            topics.
           </p>
           <p>
             <a href="#about" class="info-link">Learn more</a>
@@ -1187,23 +1192,13 @@
       <div id="covid19Vaccination" bind:this={covid19VaccinationChartContainer}>
         <div class="chart-header">
           <h3>{COVID_19_VACCINATION_TITLE}</h3>
-          <div class="info-button chart-info-button">
-            <svg
-              id="info-button-icon"
-              width="24"
-              height="24"
-              on:click={(e) => {
-                handleLegendInfoPopup(e, "#info-popup-vaccine");
-              }}
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M 12 2 C 6.48 2 2 6.48 2 12 C 2 17.52 6.48 22 12 22 C 17.52 22 22 17.52 22 12 C 22 6.48 17.52 2 12 2 Z M 11 7 V 9 H 13 V 7 H 11 Z M 11 11 V 17 H 13 V 11 H 11 Z M 4 12 C 4 16.41 7.59 20 12 20 C 16.41 20 20 16.41 20 12 C 20 7.59 16.41 4 12 4 C 7.59 4 4 7.59 4 12 Z"
-                fill="#5F6368"
-                stroke="none"
-              />
-            </svg>
+          <div
+            class="info-button chart-info-button"
+            on:click={(e) => {
+              handleLegendInfoPopup(e, "#info-popup-vaccine");
+            }}
+          >
+            <span class="material-icons-outlined">info</span>
           </div>
         </div>
         <div class="chartLegendContainer" />
@@ -1215,23 +1210,13 @@
       <div id="vaccinationIntent" bind:this={vaccinationIntentChartContainer}>
         <div class="chart-header">
           <h3>{VACCINATION_INTENT_TITLE}</h3>
-          <div class="info-button chart-info-button">
-            <svg
-              id="info-button-icon"
-              width="24"
-              height="24"
-              on:click={(e) => {
-                handleLegendInfoPopup(e, "#info-popup-intent");
-              }}
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M 12 2 C 6.48 2 2 6.48 2 12 C 2 17.52 6.48 22 12 22 C 17.52 22 22 17.52 22 12 C 22 6.48 17.52 2 12 2 Z M 11 7 V 9 H 13 V 7 H 11 Z M 11 11 V 17 H 13 V 11 H 11 Z M 4 12 C 4 16.41 7.59 20 12 20 C 16.41 20 20 16.41 20 12 C 20 7.59 16.41 4 12 4 C 7.59 4 4 7.59 4 12 Z"
-                fill="#5F6368"
-                stroke="none"
-              />
-            </svg>
+          <div
+            class="info-button chart-info-button"
+            on:click={(e) => {
+              handleLegendInfoPopup(e, "#info-popup-intent");
+            }}
+          >
+            <span class="material-icons-outlined">info</span>
           </div>
         </div>
 
@@ -1244,23 +1229,13 @@
       <div id="safetySideEffects" bind:this={safetySideEffectsChartContainer}>
         <div class="chart-header">
           <h3>{SAFETY_SIDE_EFFECTS_TITLE}</h3>
-          <div class="info-button chart-info-button">
-            <svg
-              id="info-button-icon"
-              width="24"
-              height="24"
-              on:click={(e) => {
-                handleLegendInfoPopup(e, "#info-popup-safety");
-              }}
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M 12 2 C 6.48 2 2 6.48 2 12 C 2 17.52 6.48 22 12 22 C 17.52 22 22 17.52 22 12 C 22 6.48 17.52 2 12 2 Z M 11 7 V 9 H 13 V 7 H 11 Z M 11 11 V 17 H 13 V 11 H 11 Z M 4 12 C 4 16.41 7.59 20 12 20 C 16.41 20 20 16.41 20 12 C 20 7.59 16.41 4 12 4 C 7.59 4 4 7.59 4 12 Z"
-                fill="#5F6368"
-                stroke="none"
-              />
-            </svg>
+          <div
+            class="info-button chart-info-button"
+            on:click={(e) => {
+              handleLegendInfoPopup(e, "#info-popup-safety");
+            }}
+          >
+            <span class="material-icons-outlined">info</span>
           </div>
         </div>
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -399,7 +399,7 @@ svg.map-svg path {
   margin-top: 60px;
 }
 
-.info-button svg {
+.info-button span {
   margin: 6px;
 }
 


### PR DESCRIPTION
1. Changed the info button in the map legend to display the same popups
as the charts. The popup used for the map is determined by the selected
trend line.

2. Updated the text in the popups to the latest version of the popup
text copy.

3. Cleaned up the implementation of the chart info buttons to use a
Material Icons font instead of an "embedded SVG" similar to the
implementation in the map legend.