### PR TITLE
Mobile header

### DIFF
--- a/src/TimeSeries.svelte
+++ b/src/TimeSeries.svelte
@@ -41,6 +41,8 @@
     width: 684,
     height: 276,
   };
+  //https://observablehq.com/@d3/margin-convention?collection=@d3/d3-axis
+  const margin = {top:10, bottom:30, left:0, right:30};
 
   function getLegendComponentText(): string {
     if (selectedRegion.sub_region_3) {
@@ -103,6 +105,11 @@
         .attr("class", "chart-legend-text")
         .text(legendComponentText);
     }
+    d3.select(legendContainerElement)
+      .append("div")
+      .attr("class", "chart-legend-text-container chart-axis-label")
+      .append("text")
+      .text("INTEREST");
   }
 
   function generateChartHoverCard(
@@ -458,8 +465,7 @@
     } else {
       x = chartArea
         .append("g")
-        .attr("class", "x axis")
-        .attr("transform", `translate(0, ${chartBounds.height})`);
+        .attr("class", "x axis");
     }
 
     if (yElement) {
@@ -534,10 +540,10 @@
         }
       });
     });
-
+    
     let xScale = d3
       .scaleTime()
-      .range([0, chartBounds.width])
+      .range([margin.left, chartBounds.width-margin.right])
       .domain(d3.extent(dates));
     let xAxis: d3.Axis<Date | d3.NumberValue> = d3
       .axisBottom(xScale)
@@ -550,12 +556,15 @@
 
     let yScale = d3
       .scaleLinear()
-      .range([chartBounds.height, 0])
+      .range([chartBounds.height-margin.bottom, margin.top])
       .domain([0, max]);
-    let yAxis = d3.axisRight(yScale).ticks(5).tickSize(chartBounds.width);
+    let yAxis = d3
+      .axisRight(yScale)
+      .ticks(5).tickSize(chartBounds.width-margin.right);
 
     // TODO(patankar): Define constants for styling.
     x.call(xAxis)
+      .attr("transform",`translate(0,${chartBounds.height-margin.bottom})`)
       .call((g) =>
         g.select(".domain").attr("stroke-width", 1).attr("stroke", "#80868B")
       )
@@ -573,15 +582,8 @@
           .attr("font-size", 12)
       );
     y.call(yAxis)
+    //.attr("transform",`translate(${chartBounds.width-margin.right},0)`)
       .call((g) => g.select(".domain").remove())
-      .call((g) =>
-        g
-          .selectAll(".tick")
-          .filter((t) => {
-            return t === 0;
-          })
-          .remove()
-      )
       .call((g) =>
         g
           .selectAll(".tick line")
@@ -594,18 +596,6 @@
           .attr("color", "#5F6368")
           .attr("font-family", "Roboto")
           .attr("font-size", 12)
-      )
-      .call((g) => g.select(".y-label").remove())
-      .call((g) =>
-        g
-          .append("text")
-          .attr("class", "y-label")
-          .attr("x", chartBounds.width - 15)
-          .attr("y", -10)
-          .attr("fill", "#5F6368")
-          .attr("font-family", "Roboto")
-          .attr("font-size", 11)
-          .text("INTEREST")
       );
 
     scaleChartText();
@@ -656,29 +646,23 @@
       chartXAxisElement.querySelectorAll(".tick text");
     const chartYAxisTickTextElements: NodeList =
       chartYAxisElement.querySelectorAll(".tick text");
-    const chartYAxisLabelElement: SVGElement =
-      chartYAxisElement.querySelector(".y-label");
+
     const chartXAxisTickTexts: SvgSelection = d3.selectAll(
       chartXAxisTickTextElements
     );
     const chartYAxisTickTexts: SvgSelection = d3.selectAll(
       chartYAxisTickTextElements
     );
-    const chartYAxisLabelText: SvgSelection = d3.select(chartYAxisLabelElement);
 
     const chartAreaScale: number =
       chartAreaContainerElement.getBoundingClientRect().width /
       chartBounds.width;
-
     chartXAxisTickTexts
       .attr("transform", `scale(${1 / chartAreaScale})`)
       .attr("y", `${tickSize * chartAreaScale + padding}`);
     chartYAxisTickTexts
       .attr("transform", `scale(${1 / chartAreaScale})`)
-      .attr("x", `${chartBounds.width * chartAreaScale + padding}`);
-    chartYAxisLabelText
-      .attr("transform", `scale(${1 / chartAreaScale})`)
-      .attr("x", `${chartBounds.width * chartAreaScale - 15}`);
+      .attr("x", `${(chartBounds.width-margin.right) * chartAreaScale + padding}`);
   }
 
   onMount(async () => {

--- a/src/TimeSeries.svelte
+++ b/src/TimeSeries.svelte
@@ -487,8 +487,8 @@
         .append("g")
         .append("line")
         .attr("class", "chart-vertical-line inactive")
-        .attr("y1", 0)
-        .attr("y2", chartBounds.height);
+        .attr("y1", margin.top)
+        .attr("y2", chartBounds.height-margin.bottom);
     }
 
     let data: RegionalTrends[] = Array.from(

--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -208,7 +208,7 @@
 <main>
   <header>
     <div class="header-topbar">
-      <div>
+      <div style="display: flex">
         <a href="https://www.google.com/">
           <svg role="img" aria-hidden="true" class="header-topbar-glue-logo">
             <use xlink:href="glue/glue-icons.svg#google-color-logo" />
@@ -216,21 +216,19 @@
         </a>
         <div class="header-topbar-text">COVID-19 Vaccine Search Insights</div>
       </div>
-      <ul class="header-topbar-menu">
-        <li id="download-link" class="link-item">
-          <span class="material-icons-outlined header-download-icon"
-            >file_download</span
-          >
+      <div class="header-topbar-menu">
+        <div id="download-link" class="link-item">
+          <span class="material-icons-outlined header-download-icon">file_download</span>
           Download data
-        </li>
-        <li class="link-item">
+        </div>
+        <div class="link-item">
           <a
             class="link-item-anchor"
             href="https://storage.googleapis.com/gcs-public-datasets/COVID-19%20Vaccination%20Search%20Insights%20documentation.pdf"
             >Documentation</a
           >
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
     <div id="header-download-popup" class="header-download-popup">
       <h3 class="header-downlod-popup-title">
@@ -388,23 +386,25 @@
           <div class="map-header-container">
             <div class="map-legend">
               <div class="map-legend-label">Interest</div>
-              <div class="map-legend-scale">
-                <div id="map-legend-scale-breaks" class="map-legend-scale-top">
-                  <!-- breaks added by drawLegend routine -->
+              <div style="display:flex">
+                <div class="map-legend-scale">
+                  <div id="map-legend-scale-breaks" class="map-legend-scale-top">
+                    <!-- breaks added by drawLegend routine -->
+                  </div>
+                  <div>
+                    <svg id="map-legend-swatch-bar" width="280" height="20">
+                      <!-- swatches added by drawLegend routine -->
+                    </svg>
+                  </div>
                 </div>
-                <div>
-                  <svg id="map-legend-swatch-bar" width="280" height="20">
-                    <!-- swatches added by drawLegend routine -->
-                  </svg>
+                <div
+                  class="map-info-button"
+                  on:click={(e) => {
+                    handleInfoPopup(e, selectMapInfoPopup());
+                  }}
+                >
+                  <span class="material-icons-outlined">info</span>
                 </div>
-              </div>
-              <div
-                class="map-info-button"
-                on:click={(e) => {
-                  handleInfoPopup(e, selectMapInfoPopup());
-                }}
-              >
-                <span class="material-icons-outlined">info</span>
               </div>
             </div>
             <div class="date-nav-control">

--- a/src/global.scss
+++ b/src/global.scss
@@ -296,6 +296,10 @@ footer {
   font-size: 24px;
 }
 
+svg {
+  width: inherit;
+}
+
 .map-svg {
   cursor: grab;
 }
@@ -419,7 +423,6 @@ svg.map-svg path {
 
 .chart-info-button {
   margin-top: 60px;
-  margin-right: -30px;
 }
 
 .info-popup {
@@ -435,12 +438,11 @@ svg.map-svg path {
     0px 2px 6px 2px rgba(60, 64, 67, 0.15);
   display: none;
 }
-
 .info-header {
   font-family: Roboto;
   font-weight: 500;
   font-size: 14px;
-  font-height: 20px;
+  line-height: 20px;
   letter-spacing: 0.25px;
   margin: 13px 16px 4px 16px;
 }
@@ -683,6 +685,18 @@ svg.map-svg path {
   font-size: 14px;
   font-weight: g.$body-weight;
 }
+
+.chart-axis-label {
+  margin-left: auto;
+  margin-right:0;
+  text {
+    color: g.$grey-700;
+    font-family: "Google Sans";
+    font-size: 12px;
+    font-weight: g.$body-weight;
+  }
+}
+
 
 div.next-steps-item > h3 {
   margin-top: 40px;

--- a/src/global.scss
+++ b/src/global.scss
@@ -104,11 +104,9 @@ footer {
 
 .header-topbar {
   margin-top: 20px;
-
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
 }
 
@@ -149,8 +147,9 @@ footer {
 }
 
 .header-topbar-menu {
-  margin: 0 0 0 0px;
-  list-style: none;
+  margin-left:auto;
+  
+
 }
 
 .header-content-divider {
@@ -320,6 +319,7 @@ svg.map-svg path {
 
 .map-legend {
   display: inline-flex;
+  flex-wrap: wrap;
   margin-bottom: 8px;
   font-size: 14px;
   font-family: Roboto;
@@ -737,6 +737,11 @@ div.next-steps-item > h3 {
 
   .chart-hover-card.inactive {
     display: none;
+  }
+
+  .header-search-bar{
+    padding-left: 20px;
+    padding-right: 20px;
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,14 +69,21 @@ export function handleInfoPopup(event, id): void {
   } else {
     const popup: d3.Selection<SVGGElement, any, any, any> = d3.select(id);
     const infoRect: DOMRect = event.target.getBoundingClientRect();
+    const popupRectWidth = 310;
+    const rightPadding = 20;
 
     if (activePopupId) {
       dismissInfoPopup(event);
     }
 
+    const offsetOnRight = infoRect.x + infoRect.width + window.pageXOffset;
+    
+    const left = offsetOnRight + popupRectWidth > window.innerWidth ?
+      window.innerWidth - popupRectWidth - rightPadding: offsetOnRight;
+
     popup
       .style("display", "block")
-      .style("left", `${infoRect.x + infoRect.width + window.pageXOffset}px`)
+      .style("left", `${left}px`)
       .style("top", `${infoRect.y + infoRect.height + window.pageYOffset}px`);
 
     event.stopPropagation();


### PR DESCRIPTION
Implement a fully responsive header, and as a side-effect have a fully responsive flow.  In some widths, it's not super pretty, but it at least retains all functionality at all widths down to 375px.  

Because of how the header works (i.e. width=100%), any overflowing page element will expand the header.  So, in order to have a header that actually takes only the entire viewport, also fix the chart, pop-up and legend overflows that occur down the page.

One could make the header use a width of `100vw`, but fixing the other overflows makes the mobile experience much nicer as well.

Closes #127, #118, #116, #115, #31.