### PR TITLE
Fix rounding issue in map callout cards.

### DIFF
--- a/src/choropleth.ts
+++ b/src/choropleth.ts
@@ -630,19 +630,21 @@ function drawMapCalloutInfo(data, fipsCode) {
     }
   };
 
-  let trendval: number = trends.sni_covid19_vaccination | 0;
+  // Use || here to test for existence instead of single |, otherwise the value is converted
+  // into an integer and precision is lost
+  let trendval: number = trends.sni_covid19_vaccination || 0;
   d3.select("svg#callout-vaccine")
     .select("rect")
     .style("fill", trendval == 0 ? unknownColor : colorScaleVaccine(trendval));
   d3.select("div#callout-vaccine-value").text(renderValue(trendval));
 
-  trendval = trends.sni_vaccination_intent | 0;
+  trendval = trends.sni_vaccination_intent || 0;
   d3.select("svg#callout-intent")
     .select("rect")
     .attr("fill", trendval == 0 ? unknownColor : colorScaleIntent(trendval));
   d3.select("div#callout-intent-value").text(renderValue(trendval));
 
-  trendval = trends.sni_safety_side_effects | 0;
+  trendval = trends.sni_safety_side_effects || 0;
   d3.select("svg#callout-safety")
     .select("rect")
     .attr("fill", trendval == 0 ? unknownColor : colorScaleSafety(trendval));


### PR DESCRIPTION
The routine to display the trend values for the map callout card was
testing for the existing of a value using the single |. When a value
was present this caused it to be converted to an integer and bitwise
or-ed with 0. Changed the test to use the double || - logical or
instead of bitwise or.