### PR TITLE
Update feedback link to use new form.

### DIFF
--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -662,14 +662,13 @@
         <div class="next-steps-item">
           <h3>Tell us about your project</h3>
           <p>
-            We’d love to hear more about how you’re using Vaccination Search
-            Insights. If you’ve solved problems, we’d like to help you share
-            your solutions.
+            We’d love to hear more about how you’re using the data. Send
+            feedback using our form.
           </p>
           <p>
             <a
-              href="mailto:covid-19-search-trends-feedback+webcallout@google.com"
-              >Email us
+              href="https://google-health.force.com/s/form?type=VSIFeedbackForm"
+              >Feedback
             </a>
           </p>
         </div>


### PR DESCRIPTION
Updated the feedback follow-up section to link to the new Google Health
feedback form instead of opening a mailto link.