### PR TITLE
Updating download dialog to multiple countries

### DIFF
--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -273,19 +273,34 @@
     </div>
     <div id="header-download-popup" class="header-download-popup">
       <h3 class="header-downlod-popup-title">
-        COVID-19 Vaccination Search Insights
+        Covid-19 Vaccination Search Insights
       </h3>
       <p class="header-download-popup-body">
         In order to download or use the data or insights, you must agree to the
         Google
         <a href="https://policies.google.com/terms">Terms of Service</a>.
       </p>
-      <p>
+      <h4 class = "header-download-popup-subtitle">
+        Download dataset
+      </h4>
+      <p class="header-download-popup-link-list">
         <a
           class="header-download-popup-link"
-          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/Global_vaccination_search_insights.csv"
+          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/CA_vaccination_search_insights.csv"
           on:click={(e) => closeDownloadPopup()}
-          >Download dataset - United States</a
+          ><span class="material-icons-outlined header-download-popup-icon">file_download</span>Canada</a
+        >
+        <a
+          class="header-download-popup-link"
+          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/GB_vaccination_search_insights.csv"
+          on:click={(e) => closeDownloadPopup()}
+          ><span class="material-icons-outlined header-download-popup-icon">file_download</span>United Kingdom</a
+        >
+        <a
+          class="header-download-popup-link"
+          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/US_vaccination_search_insights.csv"
+          on:click={(e) => closeDownloadPopup()}
+          ><span class="material-icons-outlined header-download-popup-icon">file_download</span>United States</a
         >
       </p>
     </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -187,9 +187,9 @@ sup {
 }
 
 .header-download-icon {
-  font-size: 16px;
   line-height: 24px;
   vertical-align: bottom;
+  margin-right: 2px;
 }
 
 .header-download-popup {
@@ -197,9 +197,8 @@ sup {
   left: 10px;
   top: 10px;
   z-index: 500;
-  width: 315px;
-  height: 115px;
-  padding: 13px 16px 13px 16px;
+  width: 370px;
+  padding: 22px 20px;
   box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3),
     0px 2px 6px 2px rgba(60, 64, 67, 0.15);
   border-radius: 8px;
@@ -217,11 +216,24 @@ sup {
 }
 
 .header-downlod-popup-title {
-  font-family: Roboto;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 20px;
   line-height: 20px;
   letter-spacing: 0.25px;
+  margin: 0px;
+}
+
+.header-download-popup-subtitle{
+  font-family: Google Sans;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.25px;
+  margin: 0px;
+  color: #5f6368;
+}
+
+.header-download-popup-link-list{
   margin: 0px;
 }
 
@@ -230,6 +242,23 @@ sup {
   font-size: 14px;
   line-height: 20px;
   letter-spacing: 0.25px;
+  display: block;
+  padding: 3px;
+  width: 170px;
+  border-radius: 5px;
+  color: #5f6368;
+}
+
+.header-download-popup-link:hover {
+  background: g.$button-hover;
+}
+
+.header-download-popup-icon{
+  font-size: 20px;
+  line-height: 24px;
+  vertical-align: bottom;
+  margin-right: 10px;
+  color: #5f6368;
 }
 
 .link-item {


### PR DESCRIPTION
Updating the download tooltip to include Canada and UK. 
Changed the US filename to be US_vaccination_search_insights.csv rather than Global_vaccination_search_insights.csv to align with changes in the back-end.

https://user-images.githubusercontent.com/33064482/141501315-37bc00cb-8f66-45f0-b377-7e3e3bcf44a3.mov
