### PR TITLE
Moving TopQueries to TrendsOverview, only show Queries for the US

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -226,11 +226,6 @@
           vaccination_intent_title={VACCINATION_INTENT_TITLE}
           safety_side_effects_title={SAFETY_SIDE_EFFECTS_TITLE}
         />
-        <TopQueries
-          covid_vaccination_button_title={COVID_19_VACCINATION_TITLE}
-          vaccination_intent_button_title={VACCINATION_INTENT_TITLE}
-          safety_side_effects_button_title={SAFETY_SIDE_EFFECTS_TITLE}
-        />
       {:else}
         <CountryPicker
           id="covid-19-vaccination"

--- a/src/TopQueries.svelte
+++ b/src/TopQueries.svelte
@@ -18,10 +18,10 @@
     import { onMount } from "svelte";
     import {
         fetchAllQueries,
-        Query,
         createDateList,
         createSerialisedQueryKey,
     } from "./data";
+    import type {Query} from "./data";
     import { params } from "./stores";
 
     const MINIMUM_DATE_INDEX = 0;

--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -37,6 +37,7 @@
   } from "./choropleth.js";
   import { fetchCountryMetaData } from "./metadata";
   import TimeSeries from "./TimeSeries.svelte";
+  import TopQueries from "./TopQueries.svelte";
 
   let selectedRegion: Region;
   let regions: Region[];
@@ -478,6 +479,14 @@
         scaled value that you can compare across regions, times, or topics.
       </p>
     </TimeSeries>
+  {/if}
+  
+  {#if selectedCountryName == "United States"}
+    <TopQueries
+      covid_vaccination_button_title={covid_vaccination_title}
+      vaccination_intent_button_title={vaccination_intent_title}
+      safety_side_effects_button_title={safety_side_effects_title}
+    />
   {/if}
 
   <a id="about" class="about-anchor">


### PR DESCRIPTION
Only showing TopQueries when selected country is US. Moving the component back to TrendsOverview, as this allows simpler country-specific selection.

Fixing small error with Query import.