### PR TITLE
Fixing unused export property warning

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -228,7 +228,6 @@
         />
       {:else}
         <CountryPicker
-          id="covid-19-vaccination"
           trendLine={(t) => {
             return t.trends.covid19_vaccination;
           }}

--- a/src/CountryPicker.svelte
+++ b/src/CountryPicker.svelte
@@ -27,7 +27,6 @@
     getClosestDate,
   } from "./utils";
 
-  export let id: string;
   export let trendLine: (trends: RegionalTrends) => TrendValue[];
 
   let globalTrendsByPlaceId: Map<string, RegionalTrends>;


### PR DESCRIPTION
Fixing this warning:
(!) Plugin svelte: CountryPicker has unused export property 'id'. If it is for external reference only, please consider using `export const id`
src/CountryPicker.svelte
