### PR TITLE
Changing 'Global' filename to 'US', removing 'staging' for the UK

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,21 +3,21 @@ SRC_DIR = public/data
 $(SRC_DIR):
 	mkdir -p $@
 	
-Global_vaccination_search_insights.csv: $(SRC_DIR)
-	curl -o $(SRC_DIR)/Global_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/Global_vaccination_search_insights.csv
+US_vaccination_search_insights.csv: $(SRC_DIR)
+	curl -o $(SRC_DIR)/US_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/US_vaccination_search_insights.csv
 
 GB_vaccination_search_insights.csv: $(SRC_DIR)
-	curl -o $(SRC_DIR)/GB_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/staging/GB_vaccination_search_insights.csv
+	curl -o $(SRC_DIR)/GB_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/GB_vaccination_search_insights.csv
 
-Global_l0_vaccination_search_insights.csv: Global_vaccination_search_insights.csv GB_vaccination_search_insights.csv
+Global_l0_vaccination_search_insights.csv: US_vaccination_search_insights.csv GB_vaccination_search_insights.csv
 	cat $(SRC_DIR)/$(word 1,$^) | awk 'NR==1' > $(SRC_DIR)/$@
 	cat $(SRC_DIR)/$(word 1,$^) | awk -vFPAT='[^,]*|"[^"]*"' -v OFS=',' 'length($$4) < 1' >> $(SRC_DIR)/$@
 	cat $(SRC_DIR)/$(word 2,$^) | awk -vFPAT='[^,]*|"[^"]*"' -v OFS=',' 'length($$4) < 1' >> $(SRC_DIR)/$@
 
 gb_regions.csv: $(SRC_DIR)/gb_regions.csv
 
-regions.csv: Global_vaccination_search_insights.csv gb_regions.csv
+regions.csv: US_vaccination_search_insights.csv gb_regions.csv
 	cat $(SRC_DIR)/$(word 1,$^) | awk -vFPAT='[^,]*|"[^"]*"' -v OFS=',' '{ print $$2,$$3,$$4,$$5,$$6,$$7,$$8,$$9,$$10 }' | uniq > $(SRC_DIR)/$@
 	cat $(SRC_DIR)/$(word 2,$^) | awk 'NR>1' >> $(SRC_DIR)/$@
 
-data: Global_l0_vaccination_search_insights.csv Global_vaccination_search_insights.csv GB_vaccination_search_insights.csv regions.csv
+data: Global_l0_vaccination_search_insights.csv US_vaccination_search_insights.csv GB_vaccination_search_insights.csv regions.csv

--- a/public/data/VSI_metadata.json
+++ b/public/data/VSI_metadata.json
@@ -26,7 +26,7 @@
         "placeId":"ChIJqZHHQhE7WgIReiWIMkOg-MQ"
    },
     {   "countryCode":"US",
-        "dataFile":"Global_vaccination_search_insights.csv",
+        "dataFile":"US_vaccination_search_insights.csv",
         "countryName":"United States",
         "displayLevels":[0,1,2,3],
         "locales":["en-US"],

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -181,7 +181,7 @@
         >
         <a
           class="header-download-popup-link"
-          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/Global_vaccination_search_insights.csv"
+          href="https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/US_vaccination_search_insights.csv"
           on:click={(e) => closeDownloadPopup()}
           ><span class="material-icons-outlined header-download-popup-icon"
             >file_download</span


### PR DESCRIPTION
The "Global_...csv" file only has the US data, so updating accordingly.
Changing the filepath for the UK data to be downloaded from prod 