### PR TITLE
Add release-it configuration

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,8 @@
+{
+  "github": {
+    "release": true
+  },
+  "npm": {
+    "publish": false
+  }
+}


### PR DESCRIPTION
By default release-it wants to publish the new release assets to the npm registry.  Since we're an app and not a lib, that doesn't make any sense for us.

In order to make releases easier to do in the future, let's add release-it configuration. e.g.
```
{
  "npm": {
    "publish": false
  }
}
```
