### PR TITLE
Fixing country selection bug

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -195,7 +195,6 @@
           <div class="header-search-container">
             <AutoComplete
               items={fetchCountryNames()}
-              bind:selectedItem={selectedCountry}
               placeholder={"Select a country"}
               onChange={onCountrySelectHandler}
               inputClassName={"header-search-box"}

--- a/src/TrendsOverview.svelte
+++ b/src/TrendsOverview.svelte
@@ -97,10 +97,11 @@
       if (placeId) {
         selectedRegion = regionsByPlaceId.get(placeId);
         selectedRegionName = getRegionName(selectedRegion);
-        selectedCountryName = getCountryName(selectedRegion);
-        if (!selectedCountryMetadata) {
-          selectedCountryMetadata =
-            fetchCountryMetaData(selectedCountryName)[0];
+        // avoid fetching country metadata if country name didn't change
+        let newCountryName = getCountryName(selectedRegion);
+        if (selectedCountryName !== newCountryName){
+          selectedCountryName = newCountryName;
+          selectedCountryMetadata = fetchCountryMetaData(selectedCountryName)[0];
         }
       }
 


### PR DESCRIPTION
Fixing country picker drop down bug. To replicate:
1. Select country from the top drop down menu
2. Go back to country picker
3. Select a different country using the buttons menu
4. Notice how it still displays the selection made using drop down menu in step 1