### PR TITLE
Moving Top Queries info pop on mobile

### DIFF
--- a/src/TopQueries.svelte
+++ b/src/TopQueries.svelte
@@ -232,7 +232,7 @@
             </button>
         </div>
         <div
-            class="info-button"
+            class="info-button info-button-top-queries"
             on:click={(e) =>
                 handleInfoPopup(e, `#info-popup-${selectedListId}`)}
         >

--- a/src/global.scss
+++ b/src/global.scss
@@ -938,6 +938,12 @@ div.next-steps-item > h3 {
   .container-header {
     top: 90px;
   }
+
+  .info-button-top-queries {
+    right: 21px;
+    margin-top: -155px;
+    position: absolute;
+  }
 }
 
 @media (min-width: g.$media-breakpoint) {


### PR DESCRIPTION
Another minor CSS bug. This time cause by the info button for Top Queries.

![image](https://user-images.githubusercontent.com/33064482/152031845-07fae7db-97b5-4507-8381-1fec533254cf.png)

Moving the button on top instead 
![image](https://user-images.githubusercontent.com/33064482/152032916-250552df-0afb-4374-b7a3-0f1633c2f299.png)