### PR TITLE
Fix repo links and switch to raw html.

### DIFF
--- a/license-report-template.html
+++ b/license-report-template.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset='utf-8'>
+	<meta name='viewport' content='width=device-width,initial-scale=1'>
+
+	<title>Third Party Notices</title>
+
+	<style>
+        #report {
+            max-width: 30em;
+        }
+        pre {
+            display: inline-block;
+            border: solid black 1px;
+            padding: 1em;
+        }
+    </style>
+</head>
+
+<body><div id="report">
+{{content}}
+</div>
+</body>
+</html>

--- a/license-report.js
+++ b/license-report.js
@@ -1,7 +1,8 @@
 //Create a simple license report html page
 var checker = require("license-checker");
 var fs = require("fs");
-var marked = require("marked");
+
+var template = fs.readFileSync("license-report-template.html").toString();
 
 checker.init(
   {
@@ -12,22 +13,21 @@ checker.init(
       console.log(err);
     } else {
       var report = "";
-      //Use simple markdown to create each entry
       for (package in packages) {
         let package_info = packages[package];
         let licenseText = fs.readFileSync(package_info.licenseFile);
         let entry =
-          `# [${package}](package_info.repository)\n` +
-          `Publisher: ${package_info.publisher}\n` +
-          `License:${package_info.licenses}\n` +
-          `## License Text\n` +
-          licenseText.toString() +
-          "\n";
+          `<h2><a href="${package_info.repository}">${package}</a></h2>` +
+          (package_info.publisher
+            ? `<p>Publisher: ${package_info.publisher}</p>`
+            : "") +
+          `<p>License: ${package_info.licenses}</p>` +
+          `<h3>License Text</h3>` +
+          `<p><pre>${licenseText.toString()}</pre></p>`;
         report += entry;
       }
-      //then render the markdown to html
-      let html_report = marked.parse(report);
-      console.log(html_report);
+      let output = template.replace("{{content}}", report);
+      console.log(output);
     }
   }
 );

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "ansi-regex": "^6.0.1",
     "license-checker": "^25.0.1",
-    "marked": "^4.0.12",
     "sirv-cli": "^1.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
Links to the repo homepages were broken.  I also switched back to raw html since it occurred to me we should not interpret license text as markdown and instead display it exactly.

I also added a html template with an area for CSS in case we ever want to change styles.

![image](https://user-images.githubusercontent.com/46794497/155405458-ff4c4392-8d4d-49d5-bb8f-ed18fb2f6d9f.png)
