### PR TITLE
Update makefile to get US file size under 100MB

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,9 +2,10 @@ SRC_DIR = public/data
 
 $(SRC_DIR):
 	mkdir -p $@
-	
+
 US_vaccination_search_insights.csv: $(SRC_DIR)
-	curl -o $(SRC_DIR)/US_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/US_vaccination_search_insights.csv
+	curl https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/US_vaccination_search_insights.csv |\
+	grep -v "2021\-0[12]" > $(SRC_DIR)/US_vaccination_search_insights.csv
 
 GB_vaccination_search_insights.csv: $(SRC_DIR)
 	curl -o $(SRC_DIR)/GB_vaccination_search_insights.csv https://storage.googleapis.com/covid19-open-data/covid19-vaccination-search-insights/GB_vaccination_search_insights.csv


### PR DESCRIPTION
File size is reduced by filtering out 2021 Jan and Feb data for the US. This is a temporary workaround so that we can release newer data.